### PR TITLE
Add new explicit boolean type (fixes (or #f #f)); add primitives for displaying and comparing

### DIFF
--- a/packages/QoppaS-Core.package/QoppaBoolean.class/instance/content..st
+++ b/packages/QoppaS-Core.package/QoppaBoolean.class/instance/content..st
@@ -1,0 +1,4 @@
+printing
+content: aBoolean
+
+	content := aBoolean

--- a/packages/QoppaS-Core.package/QoppaBoolean.class/instance/content.st
+++ b/packages/QoppaS-Core.package/QoppaBoolean.class/instance/content.st
@@ -1,0 +1,4 @@
+printing
+content
+
+	^ content

--- a/packages/QoppaS-Core.package/QoppaBoolean.class/methodProperties.json
+++ b/packages/QoppaS-Core.package/QoppaBoolean.class/methodProperties.json
@@ -1,0 +1,6 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"content" : "tobe 1/8/2021 23:47",
+		"content:" : "tobe 1/8/2021 23:47" } }

--- a/packages/QoppaS-Core.package/QoppaBoolean.class/properties.json
+++ b/packages/QoppaS-Core.package/QoppaBoolean.class/properties.json
@@ -1,0 +1,16 @@
+{
+	"category" : "QoppaS-Core",
+	"classinstvars" : [
+		 ],
+	"classtraitcomposition" : "QoppaPrintable classTrait",
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		"content" ],
+	"name" : "QoppaBoolean",
+	"pools" : [
+		 ],
+	"super" : "Object",
+	"traitcomposition" : "QoppaPrintable",
+	"type" : "normal" }

--- a/packages/QoppaS-Core.package/QoppaFexprSemantic.class/instance/atomBoolean.with.with..st
+++ b/packages/QoppaS-Core.package/QoppaFexprSemantic.class/instance/atomBoolean.with.with..st
@@ -1,0 +1,3 @@
+actions
+atomBoolean: aNode with: x with: charsNode
+	^ aNode interval contents = '#t'

--- a/packages/QoppaS-Core.package/QoppaFexprSemantic.class/instance/parseFile..st
+++ b/packages/QoppaS-Core.package/QoppaFexprSemantic.class/instance/parseFile..st
@@ -3,5 +3,5 @@ parseFile: someCode
 	"Return OhmMatchResult for parsing someCode"
 	| result |
 	result := self grammar match: someCode startingFrom: 'File'.
-	"(result isKindOf: OhmNode) ifTrue: [ result failure signal]."
+	result failed ifTrue: [ result failure signal].
 	^ result

--- a/packages/QoppaS-Core.package/QoppaFexprSemantic.class/methodProperties.json
+++ b/packages/QoppaS-Core.package/QoppaFexprSemantic.class/methodProperties.json
@@ -13,6 +13,7 @@
 		"SExpressionSimpleQuoted:with:withExpression:" : "jr 2/1/2016 16:04",
 		"addSource:for:" : "jr 2/2/2016 01:00",
 		"atom:with:" : "bak 10/30/2015 13:54",
+		"atomBoolean:with:with:" : "tobe 1/8/2021 23:53",
 		"atomNull:with:" : "jr 2/1/2016 14:15",
 		"atomNumber:with:" : "bak 11/10/2015 14:44",
 		"atomString:with:with:with:" : "jr 2/1/2016 14:19",

--- a/packages/QoppaS-Core.package/QoppaFexprSemantic.class/methodProperties.json
+++ b/packages/QoppaS-Core.package/QoppaFexprSemantic.class/methodProperties.json
@@ -21,7 +21,7 @@
 		"atomVariable:with:" : "jr 2/1/2016 16:15",
 		"grammar" : "bak 1/26/2017 14:26",
 		"initialize" : "jr 2/2/2016 01:17",
-		"parseFile:" : "bak 1/26/2017 14:28",
+		"parseFile:" : "tobe 1/10/2021 15:27",
 		"quote:" : "jr 2/1/2016 16:04",
 		"readFile:" : "jr 2/1/2016 14:33",
 		"rememberInterval:inSourceOf:for:" : "jr 2/2/2016 00:58",

--- a/packages/QoppaS-Core.package/QoppaGrammar.class/class/serializedGrammar.st
+++ b/packages/QoppaS-Core.package/QoppaGrammar.class/class/serializedGrammar.st
@@ -17,7 +17,8 @@ SExpression
 
 atom
   = number -- number
-   | ("''" | "#") standard_char+ -- symbol
+   | "#" ("t" | "f") -- boolean
+   | "''" standard_char+ -- symbol
    | "\"" (escaped_char|standard_char|space)+ "\"" -- string
    | "null" ~ standard_char -- null
    | standard_char+  -- variable

--- a/packages/QoppaS-Core.package/QoppaGrammar.class/class/serializedGrammar.st
+++ b/packages/QoppaS-Core.package/QoppaGrammar.class/class/serializedGrammar.st
@@ -12,14 +12,14 @@ List
 SExpression
   = List   -- list
    | atom -- atom
-   | "''" SExpression -- simple_quoted
+   | "''" List -- simple_quoted
    | "`" SExpression  -- quasi_quoted
 
 atom
   = number -- number
    | "#" ("t" | "f") -- boolean
    | "''" standard_char+ -- symbol
-   | "\"" (escaped_char|standard_char|space)+ "\"" -- string
+   | "\"" (escaped_char|standard_char|space|"''")* "\"" -- string
    | "null" ~ standard_char -- null
    | standard_char+  -- variable
 

--- a/packages/QoppaS-Core.package/QoppaGrammar.class/methodProperties.json
+++ b/packages/QoppaS-Core.package/QoppaGrammar.class/methodProperties.json
@@ -1,5 +1,5 @@
 {
 	"class" : {
-		"serializedGrammar" : "tobe 1/8/2021 18:41" },
+		"serializedGrammar" : "tobe 1/8/2021 23:53" },
 	"instance" : {
 		 } }

--- a/packages/QoppaS-Core.package/QoppaGrammar.class/methodProperties.json
+++ b/packages/QoppaS-Core.package/QoppaGrammar.class/methodProperties.json
@@ -1,5 +1,5 @@
 {
 	"class" : {
-		"serializedGrammar" : "tobe 1/8/2021 23:53" },
+		"serializedGrammar" : "tobe 1/10/2021 15:38" },
 	"instance" : {
 		 } }

--- a/packages/QoppaS-Core.package/QoppaInterpreter.class/instance/buildGlobalEnv.st
+++ b/packages/QoppaS-Core.package/QoppaInterpreter.class/instance/buildGlobalEnv.st
@@ -8,8 +8,11 @@ buildGlobalEnv
 		#/   -> (self wrapPrim: [:args| args reduce: [:a :b| a / b]] countingArgs: false).
 		#quo   -> (self wrapPrim: [:a :b| a \\ b] countingArgs: true).
 		#<=  -> (self wrapPrim: [:args| self toQoppaBoolean: (args reduce: [:a :b| a <= b])] countingArgs: false).
+		#>  -> (self wrapPrim: [:args| self toQoppaBoolean: (args reduce: [:a :b| a > b])] countingArgs: false).
+		#>=  -> (self wrapPrim: [:args| self toQoppaBoolean: (args reduce: [:a :b| a >= b])] countingArgs: false).
 		#<  -> (self wrapPrim: [:args| self toQoppaBoolean: (args reduce: [:a :b| a < b])] countingArgs: false).
 		#=  -> (self wrapPrim: [:args| self toQoppaBoolean: (args reduce: [:a :b| a = b])] countingArgs: false).
+		#'eq?' -> (self wrapPrim: [:args| self toQoppaBoolean: (args reduce: [:a :b| a = b])] countingArgs: false).
 		
 		#cons -> (self wrapPrim: [:car :cdr| QoppaWCons withCar: car cdr: cdr] countingArgs: true).
 		#car -> (self wrapPrim: [:cons| cons car] countingArgs: true).
@@ -27,4 +30,6 @@ buildGlobalEnv
 		#operate -> (self wrapPrim: [:env :operative :operands| self operate: operative on: operands in: env] countingArgs: true).
 		#halt -> self haltPrimitive.
 		#load -> self loadPrimitive.
+		#display -> (self wrapPrim: [:operand| Transcript show: operand. operand] countingArgs: true).
+		#newline -> (self wrapPrim: [Transcript cr] countingArgs: true).
 	})).

--- a/packages/QoppaS-Core.package/QoppaInterpreter.class/instance/buildGlobalEnv.st
+++ b/packages/QoppaS-Core.package/QoppaInterpreter.class/instance/buildGlobalEnv.st
@@ -2,9 +2,9 @@ environments
 buildGlobalEnv
 	^QoppaWCons withCar: (QoppaWCons newAssociationListFrom: (self wrapKeysIn: {
 		#vau -> self vauPrim.
-		#+ -> (self wrapPrim: [:args| args reduce: [:a :b| a + b] ifEmpty: [0]] countingArgs: false).
-		#-  -> (self wrapPrim: [:args| args reduce: [:a :b| a - b]] countingArgs: false).
-		#*  -> (self wrapPrim: [:args| args reduce: [:a :b| a * b] ifEmpty: [1]] countingArgs: false).
+		#+ -> (self wrapPrim: [:args| args inject: 0 into: [:a :b| a + b]] countingArgs: false).
+		#-  -> (self wrapPrim: [:args| args size = 1 ifTrue: [args first negated] ifFalse: [args reduce: [:a :b| a - b]]] countingArgs: false).
+		#*  -> (self wrapPrim: [:args| args inject: 1 into: [:a :b| a * b]] countingArgs: false).
 		#/   -> (self wrapPrim: [:args| args reduce: [:a :b| a / b]] countingArgs: false).
 		#quo   -> (self wrapPrim: [:a :b| a \\ b] countingArgs: true).
 		#<=  -> (self wrapPrim: [:args| self toQoppaBoolean: (args reduce: [:a :b| a <= b])] countingArgs: false).

--- a/packages/QoppaS-Core.package/QoppaInterpreter.class/instance/eval.in..st
+++ b/packages/QoppaS-Core.package/QoppaInterpreter.class/instance/eval.in..st
@@ -1,5 +1,7 @@
 interpreting
 eval: expression in: env
+	expression isBoolean
+		ifTrue: [^expression].
 	expression isNumber
 		ifTrue: [^expression].
 	expression isQuoted

--- a/packages/QoppaS-Core.package/QoppaInterpreter.class/instance/falseValue.st
+++ b/packages/QoppaS-Core.package/QoppaInterpreter.class/instance/falseValue.st
@@ -1,3 +1,3 @@
 built-in objects
 falseValue
-	^ #f
+	^ false

--- a/packages/QoppaS-Core.package/QoppaInterpreter.class/instance/trueValue.st
+++ b/packages/QoppaS-Core.package/QoppaInterpreter.class/instance/trueValue.st
@@ -1,3 +1,3 @@
 built-in objects
 trueValue
-	^ #t
+	^ true

--- a/packages/QoppaS-Core.package/QoppaInterpreter.class/instance/wrapPrim.countingArgs..st
+++ b/packages/QoppaS-Core.package/QoppaInterpreter.class/instance/wrapPrim.countingArgs..st
@@ -11,6 +11,6 @@ wrapPrim: aBlock countingArgs: countArgs
 				ifFalse: [aBlock value: evaluatedArgs]
 				ifTrue: [		
 					aBlock numArgs = args size
-					ifTrue: [ aBlock valueWithArguments: evaluatedArgs]
+					ifTrue: [ aBlock valueWithArguments: evaluatedArgs asArray]
 					ifFalse: [ QoppaArityMismatchError signal: 'ArityMismatch for', aBlock]]];
 		yourself

--- a/packages/QoppaS-Core.package/QoppaInterpreter.class/methodProperties.json
+++ b/packages/QoppaS-Core.package/QoppaInterpreter.class/methodProperties.json
@@ -4,10 +4,10 @@
 	"instance" : {
 		"bind:to:" : "bak 9/21/2017 19:34",
 		"boolPrim" : "jr 2/1/2016 15:33",
-		"buildGlobalEnv" : "bak 2/16/2017 19:20",
+		"buildGlobalEnv" : "tobe 1/8/2021 21:19",
 		"cons:with:" : "jr 2/1/2016 14:58",
-		"eval:in:" : "bak 3/8/2017 11:46",
-		"falseValue" : "jr 2/1/2016 14:27",
+		"eval:in:" : "tobe 1/8/2021 23:48",
+		"falseValue" : "tobe 1/8/2021 23:48",
 		"globalEnv" : "jr 2/1/2016 13:54",
 		"globalEnv:" : "jr 2/1/2016 13:54",
 		"haltPrimitive" : "jr 2/1/2016 15:34",
@@ -20,8 +20,8 @@
 		"reader" : "jr 2/1/2016 13:54",
 		"reader:" : "jr 2/1/2016 13:54",
 		"toQoppaBoolean:" : "jr 2/1/2016 14:38",
-		"trueValue" : "jr 2/1/2016 14:38",
+		"trueValue" : "tobe 1/8/2021 23:48",
 		"vau:withParameters:withEnvironmentParameter:in:" : "bak 9/21/2017 19:34",
 		"vauPrim" : "jr 2/1/2016 15:34",
 		"wrapKeysIn:" : "jr 2/2/2016 01:39",
-		"wrapPrim:countingArgs:" : "tobe 1/6/2021 15:18" } }
+		"wrapPrim:countingArgs:" : "tobe 1/8/2021 22:52" } }

--- a/packages/QoppaS-Core.package/QoppaInterpreter.class/methodProperties.json
+++ b/packages/QoppaS-Core.package/QoppaInterpreter.class/methodProperties.json
@@ -4,7 +4,7 @@
 	"instance" : {
 		"bind:to:" : "bak 9/21/2017 19:34",
 		"boolPrim" : "jr 2/1/2016 15:33",
-		"buildGlobalEnv" : "tobe 1/8/2021 21:19",
+		"buildGlobalEnv" : "tobe 1/10/2021 16:29",
 		"cons:with:" : "jr 2/1/2016 14:58",
 		"eval:in:" : "tobe 1/8/2021 23:48",
 		"falseValue" : "tobe 1/8/2021 23:48",
@@ -24,4 +24,4 @@
 		"vau:withParameters:withEnvironmentParameter:in:" : "bak 9/21/2017 19:34",
 		"vauPrim" : "jr 2/1/2016 15:34",
 		"wrapKeysIn:" : "jr 2/2/2016 01:39",
-		"wrapPrim:countingArgs:" : "tobe 1/8/2021 22:52" } }
+		"wrapPrim:countingArgs:" : "tobe 1/10/2021 15:54" } }

--- a/packages/QoppaS-Core.package/QoppaPrelude.class/class/prelude.st
+++ b/packages/QoppaS-Core.package/QoppaPrelude.class/class/prelude.st
@@ -130,6 +130,12 @@ prelude
         z
         (f (car xs) (foldr f z (cdr xs)))))
 
+(define (filter f z)
+    (cond
+		((null? z) z)
+		((not (f (car z))) (filter f (cdr z)))
+		(else (cons (car z) (filter f (cdr z))))))
+
 (define (append a b)
     (foldr cons b a))
 

--- a/packages/QoppaS-Core.package/QoppaPrelude.class/methodProperties.json
+++ b/packages/QoppaS-Core.package/QoppaPrelude.class/methodProperties.json
@@ -4,7 +4,7 @@
 		"factWithHalt" : "bak 3/1/2016 18:41",
 		"factWithTypo" : "bak 3/1/2016 17:58",
 		"integerDiv" : "bak 2/16/2017 22:25",
-		"prelude" : "bak 4/27/2016 10:52",
+		"prelude" : "tobe 1/10/2021 16:04",
 		"smallPrelude" : "jr 2/1/2016 15:55" },
 	"instance" : {
 		 } }

--- a/packages/QoppaS-Tests.package/QoppaOrTest.class/instance/testBool.st
+++ b/packages/QoppaS-Tests.package/QoppaOrTest.class/instance/testBool.st
@@ -1,0 +1,6 @@
+tests
+testBool
+	self assert: false equals: (self readAndEvaluate: '(or #f #f #f)').
+	self assert: false equals: (self readAndEvaluate: '(and #t #t #f)').
+	self assert: true equals: (self readAndEvaluate: '(or #f #f #t)').
+	self assert: true equals: (self readAndEvaluate: '(and #t #t #t)').

--- a/packages/QoppaS-Tests.package/QoppaOrTest.class/methodProperties.json
+++ b/packages/QoppaS-Tests.package/QoppaOrTest.class/methodProperties.json
@@ -1,0 +1,5 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"testBool" : "tobe 1/8/2021 23:55" } }

--- a/packages/QoppaS-Tests.package/QoppaOrTest.class/properties.json
+++ b/packages/QoppaS-Tests.package/QoppaOrTest.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"category" : "QoppaS-Tests",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		 ],
+	"name" : "QoppaOrTest",
+	"pools" : [
+		 ],
+	"super" : "QoppaTest",
+	"type" : "normal" }

--- a/packages/QoppaS-Tests.package/QoppaParseTest.class/instance/testFails.st
+++ b/packages/QoppaS-Tests.package/QoppaParseTest.class/instance/testFails.st
@@ -1,3 +1,3 @@
 as yet unclassified
 testFails
-	self assert: nil equals:(self readAndEvaluate: '"1')
+	self should: [self readAndEvaluate: '"1'] raise: OhmMatchFailure

--- a/packages/QoppaS-Tests.package/QoppaParseTest.class/instance/testParseHashSymbol.st
+++ b/packages/QoppaS-Tests.package/QoppaParseTest.class/instance/testParseHashSymbol.st
@@ -1,4 +1,4 @@
 as yet unclassified
 testParseHashSymbol
 	"should not raise"
-	self parse: '(cons #+ ''())'.
+	self parse: '(cons ''+ ''())'.

--- a/packages/QoppaS-Tests.package/QoppaParseTest.class/methodProperties.json
+++ b/packages/QoppaS-Tests.package/QoppaParseTest.class/methodProperties.json
@@ -2,7 +2,7 @@
 	"class" : {
 		 },
 	"instance" : {
-		"testFails" : "bak 3/22/2017 19:06",
+		"testFails" : "bak 1/11/2021 10:57",
 		"testParseComment" : "jr 2/1/2016 13:44",
 		"testParseDefineDefinition" : "bak 1/26/2017 14:48",
 		"testParseEmptyList" : "jr 2/1/2016 13:44",

--- a/packages/QoppaS-Tests.package/QoppaParseTest.class/methodProperties.json
+++ b/packages/QoppaS-Tests.package/QoppaParseTest.class/methodProperties.json
@@ -7,7 +7,7 @@
 		"testParseDefineDefinition" : "bak 1/26/2017 14:48",
 		"testParseEmptyList" : "jr 2/1/2016 13:44",
 		"testParseExplicitCdr" : "jr 2/1/2016 15:57",
-		"testParseHashSymbol" : "bak 6/23/2016 08:19",
+		"testParseHashSymbol" : "tobe 1/9/2021 00:00",
 		"testParseList" : "bak 6/23/2016 08:20",
 		"testParseMultiline" : "jr 2/1/2016 13:44",
 		"testParseQuotedList" : "bak 6/23/2016 08:20",


### PR DESCRIPTION
Not sure if that's just something I did entirely wrong or ported incorrectly but an expression such as `(or #f #f)` would either error in "no binding for f" or return #t. I found that the original implementation of Qoppa [1] does not turn booleans into Symbols so I changed things to use the primitive boolean from Smalltalk throughout instead. Things then started working.

One test asserted for the existence of "hash symbols" which aren't valid in DrRacket/r5rs, however. Is this a later addition to the language? As part of this part I turned this into a regular Symbol starting with `'`.

[1] https://github.com/kmcallister/qoppa/blob/master/qoppa.scm#L24